### PR TITLE
Make PyQt5 an optional dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ install_requires =
     matplotlib
     scikit-image
     wget
-    PyQt5
 
 python_requires = >=3.8
 setup_requires =
@@ -54,6 +53,8 @@ dev =
     pyinstaller
 testing =
     pytest
+pyqt5 = 
+    pyqt5
 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
This PR removes the pyqt5 dep in favour of making install optional, with this PR the install instructions should be updated to something like

`pip install occupy[pyqt5]`

Some shells (zsh) auto escape square brackets so

`pip install "occupy[pyqt5]"` is more guaranteed to work

## context

pip install fails routinely on M1 machines because the pyqt5 wheel available on pip is borked - installing the `pyqt` conda package instead is a workaround but installing occupy fails because it still tries to build the wheel


Signed-off-by: alisterburt <alisterburt@gmail.com>