### PR TITLE
Fix visualising large maps in ChimeraX

### DIFF
--- a/occupy_lib/vis.py
+++ b/occupy_lib/vis.py
@@ -37,7 +37,7 @@ def chimx_viz(
         # -----MODELS --------------------------------------
         print(f'open \"{input}\"', file=the_file)
         if threshold_maps is not None:
-            print(f'vol #1 level {threshold_maps}', file=the_file)
+            print(f'vol #1 style surface region all level {threshold_maps}', file=the_file)
 
         print(f'open \"{scale}\" ', file=the_file)
         if threshold_scale is not None:


### PR DESCRIPTION
Large maps open in ChimeraX in the "plane" view by default; this causes an error when trying to change the level or colour of the volume. `style surface region all` switches the mode to surface and displays all slices, matching the default for smaller maps. These options should not affect smaller maps that are displayed correctly by default.