### PR TITLE
Don't close Log panel of ChimeraX

### DIFF
--- a/occupy_lib/vis.py
+++ b/occupy_lib/vis.py
@@ -147,7 +147,6 @@ def chimx_viz(
         # ------LIGHTING-------------------------------------
         print(f'lighting soft \n', file=the_file)
         print(f'set bgColor white', file=the_file)
-        print(f'tool hide log', file=the_file)
 
         if warnings is not None:
             size = 20


### PR DESCRIPTION
Hello,

I suggest this minor change so that the ChimeraX script generated by OccuPy doesn't close the Log panel.

I think it is fine for this script to do anything it wants in the 3D view panel (obviously), and to define new commands. But I believe that changing the UI should be off-limit. The ChimeraX UI is very customizable: one can choose to dock panels in a certain arrangement. Once used to a custom UI that supports how one uses ChimeraX, it is annoying to have these preferences overwritten by external tools.
This is just a suggestion and I could be convinced it's not a good one, so no hard feelings if this PR won't be merged. 🙂

Cheers